### PR TITLE
make ivoba/console-service-provider a suggestion instead of a require…

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $application->add(new Consumer());
 $application->run();
 ```
 
-We rely on the [Ivoba\Silex\Provider\ConsoleServiceProvider](https://github.com/ivoba/console-service-provider) to make things easier, so you have to register it too. You can create new commands by inheriting from the example Consumer, and adding them as the example above.
+In this exemple we rely on the [Ivoba\Silex\Provider\ConsoleServiceProvider](https://github.com/ivoba/console-service-provider) to make things easier, so you have to install it too. You can create new commands by inheriting from the example Consumer, and adding them as the example above.
 
 
 ## Credits ##

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
     "require": {
         "php": ">=5.5.0",
         "silex/silex": "~1.3",
-        "php-amqplib/rabbitmq-bundle": "~1.9",
-        "ivoba/console-service-provider": "~2.0"
+        "php-amqplib/rabbitmq-bundle": "~1.9"
+    },
+    "suggest": {
+        "ivoba/console-service-provider": "for the rabbitmq:consumer command"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
the ConsoleServiceProvider is not really a dependency. It's usefull but others might use different tools for this

this PR makes it a suggestion so that it's not downloaded when it's not needed

note: might be better to release this with the Silex 2 compatibility in 2.x as it might break a project that rely on this dependency